### PR TITLE
商品編集機能の実装

### DIFF
--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,0 +1,135 @@
+.all
+  .wrapper
+    = render "/shared/header"
+
+  .sale
+    .sale__files
+      - unless !flash[:error_messages]
+        .alert-danger
+          %ul
+            - flash[:error_messages].each do |msg|
+              %li= msg
+      = form_with model:@item, local:true do |f|
+        %h2.sell__block__head
+          商品の情報を入力
+        .sell__block__form
+          .sell__block__form__upload
+            %h3.sell__block__form__upload__head
+              出品画像
+              %span.require 必須
+            %p 最大5枚までアップロードできます
+            .post__drop__box__container
+              .prev-content
+
+                //JSで挿入したhtmlと同じ形 each文でのプレビュー表示
+                - @item.photos.each do |photo|
+                  .preview-box
+                    .upper-box
+                      = image_tag photo.image.url, width: "112", height: "112", alt: "preview"
+                      -# = image_tag image.image.url, width: "112", height: "112", alt: "preview"
+                    .lower-box
+                      .delete-box
+                        .delete-btn
+                          %span 削除
+              .label-content
+              
+                //プレビューの数に合わせてforオプションを指定
+                = f.label :"photos_attributes_#{@item.photos.length}_image", class: "label-box", id: "label-box--#{@item.photos.length}" do
+                  %pre.label-box__text-visible クリックしてファイルをアップロード
+              .hidden-content
+                = f.fields_for :photos do |i|
+
+                  //プレビューが出ている分のfile_fieldとdelete用のチェックボックスを設置
+                  = i.file_field :image, class: "hidden-field"
+                  = i.check_box:_destroy, class: "hidden-checkbox"
+
+                  //5つのfile_fieldを準備するに当たって、足りない分を表示
+                - @item.photos.length.upto(4) do |i|
+                  %input{name: "item[photos_attributes][#{i}][image]", id: "item_photos_attributes_#{i}_image", class:"hidden-field", type:"file"}
+          
+        .sale__files__name
+          .sale__files__name__comment1
+            .sale__files__name__comment1__box1
+              商品名
+            .sale__files__name__comment1__box2
+              ※必須
+          .sale__files__name__form
+            = f.text_field :name, placeholder: "商品名を入力",class:"sale__files__name__form__input"
+        .sale__files__description
+          .sale__files__description__comment2
+            .sale__files__description__comment2__box3
+              商品説明
+            .sale__files__description__comment2__box4
+              ※必須
+          .sale__files__description__form
+            = f.text_field :description, placeholder: "商品説明を入力",class:"sale__files__description__form__input"
+        .sale__files__categori
+          .sale__files__categori__comment3
+            .sale__files__categori__comment3__box5
+              カテゴリ
+            .sale__files__categori__comment3__box6
+              ※必須
+          .sale__files__categori__form
+            .listing-select-wrapper
+              .listing-select-wrapper__box
+                .wrapper.category-wrapper
+                  = f.label :category_id , class: 'wrapper__label category-wrapper-label', id: "wrapper__label--category" do
+                    .category-wrapper__box--select
+                      = f.select :category_id, @category_parent_array, {}, {class: 'listing-select-wrapper__box--select', id: 'parent_category'}
+                    .listing-select-wrapper__box#children_wrapper
+                      .category-wrapper__box--select
+                        = f.select :child_id, options_for_select(@category_children_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "指定なし", selected: @item.category.parent.id}),{}, {class: 'category-wrapper__category form-control', id: 'child_category'}
+                    .listing-select-wrapper__box#grandchildren_wrapper
+                      .category-wrapper__box--select
+                        = f.select :category_id, options_for_select(@category_grandchildren_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "指定なし", selected: @item.category.id}),{}, {class: 'category-wrapper__category form-control', id: 'grandchild_category'}
+        .sale__files__brand
+          .sale__files__brand__comment4
+            .sale__files__brand__comment4__box7
+              ブランド
+            .sale__files__brand__comment4__space
+            ="　　　"
+          .sale__files__brand__form
+            = f.text_field :brand, placeholder: "ブランド名を入力",class:"sale__files__brand__form__input"
+        .sale__files__status
+          .sale__files__status__comment9
+            .sale__files__status__comment9__box16
+              商品の状態
+            .sale__files__status__comment9__box17
+              ※必須
+          .sale__files__status__form
+            = f.collection_select :status, Statushash.all, :id, :name,prompt:"選択してください",class:"sale__files__status__form__input"
+        .sale__files__postage
+          .sale__files__postage__comment5
+            .sale__files__postage__comment5__box8
+              配送料の負担
+            .sale__files__postage__comment5__box9
+              ※必須
+          .sale__files__postage__form
+            = f.collection_select :shipping_charges,Postagehash.all, :id, :name,prompt:"選択してください",class:"sale__files__postage__form__input"
+        .sale__files__shipping
+          .sale__files__shipping__comment6
+            .sale__files__shipping__comment6__box10
+              発送日の目安
+            .sale__files__shipping__comment6__box11
+              ※必須
+          .sale__files__shipping__form
+            = f.collection_select :days_to_ship,Shippinghash.all, :id, :name,prompt:"選択してください",class:"sale__files__shipping__form__input"
+        .sale__files__area
+          .sale__files__area__comment8
+            .sale__files__area__comment8__box14
+              発送元
+            .sale__files__area__comment8__box15
+              ※必須
+          .sale__files__area__form
+            = f.collection_select :area, Aprefecture.all, :id, :name,class:"sale__files__area__form__input",prompt:"選択してください"
+        .sale__files__price
+          .sale__files__price__comment7
+            .sale__files__price__comment7__box12
+              商品価格
+            .sale__files__price__comment7__box13
+              ※必須
+          .sale__files__price__form
+            = f.text_field :price, placeholder: "価格を入力",class:"sale__files__price__form__input"
+        =  f.submit "編集",class:"sale__files__submit"
+        .footer
+          =render "/shared/footer"


### PR DESCRIPTION
# what
商品編集機能を実装いたしました。
出品機能と一緒のUIで実装しました。
本番環境でも動作確認済みです。

# why
商品の画像を足したいときや値段などの条件を出品してから変更できるようにするため。
編集時も項目の抜けがあると、他のユーザーが商品の状態や、詳細を把握することができなくなるため。

●商品編集ボタンを押すと出品時の情報が表示されている
https://gyazo.com/050e78cd04647af3f9c68312a75c4064
●商品編集成功
https://gyazo.com/048dde25e79b295cca34e6b7ed394b5e
●エラーハンドリング
https://gyazo.com/6eca6074ba43a153a6095fdbd8c7e584