### PR TITLE
購入済み商品削除

### DIFF
--- a/app/views/shared/_main5.html.haml
+++ b/app/views/shared/_main5.html.haml
@@ -9,6 +9,8 @@
     .productlists
       .productlists__productlist
         - @items.each do |item|
+          -if item.buyer_id.present? 
+          -else
             .productlists__productlist__box
               .productlists__productlist__box__top
                 =link_to item_path(item) do


### PR DESCRIPTION
# WHAT
購入済み商品が表示されない機能を実装

# WHY
購入済みの商品を表示しないことで同じ商品を２人以上が購入するのを防ぐため